### PR TITLE
as_matrix replaced

### DIFF
--- a/src/lstnet.py
+++ b/src/lstnet.py
@@ -79,7 +79,7 @@ def build_iters(data_dir, max_records, q, horizon, splits, batch_size):
     # Read in data as numpy array
     df = pd.read_csv(os.path.join(data_dir, "electricity.txt"), sep=",", header=None)
     feature_df = df.iloc[:, :].astype(float)
-    x = feature_df.as_matrix()
+    x = feature_df.values
     x = x[:max_records] if max_records else x
 
     # Construct training examples based on horizon and window


### PR DESCRIPTION
as_matrix() got removed with Pandas 1.0.0 (https://github.com/pandas-dev/pandas/pull/18458), replaced with values